### PR TITLE
Set console sink log level to warning to reduce spam

### DIFF
--- a/sdk_core/base/logging.cpp
+++ b/sdk_core/base/logging.cpp
@@ -38,7 +38,7 @@ void InitLogger() {
   std::vector<spdlog::sink_ptr> sinkList;
   if (is_console_log_enable) {
     auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    consoleSink->set_level(spdlog::level::debug);
+    consoleSink->set_level(spdlog::level::warn);
     sinkList.push_back(consoleSink);
   }
 


### PR DESCRIPTION
In order to avoid a lot of unnecessary messages at startup.