### PR TITLE
Add missing header file to compile on Ubuntu 24.04 Noble

### DIFF
--- a/sdk_core/logger_handler/file_manager.h
+++ b/sdk_core/logger_handler/file_manager.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_FILE_MANAGER_
 #define LIVOX_FILE_MANAGER_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
On Ubuntu 24.04 compiling the sdk failed with the following error:
```
In file included from /opt/enway/ros2_ws/src/enway_ros2/hardware/livox_ros_driver2/src/livox_sdk2/sdk_core/logger_handler/file_manager.cpp:25:
/opt/enway/ros2_ws/src/enway_ros2/hardware/livox_ros_driver2/src/livox_sdk2/sdk_core/logger_handler/file_manager.h:35:1: error: ‘uint64_t’ does not name a type
   35 | uint64_t GetDirTotalSize(const std::string& dir_name);
      | ^~~~~~~~
/opt/enway/ros2_ws/src/enway_ros2/hardware/livox_ros_driver2/src/livox_sdk2/sdk_core/logger_handler/file_manager.h:31:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   30 | #include <map>
  +++ |+#include <cstdint>
   31 |
```

adding the include fixed the problem.